### PR TITLE
#234 Improve action handling flow

### DIFF
--- a/example/workflow/extension/package.json
+++ b/example/workflow/extension/package.json
@@ -28,19 +28,19 @@
     ],
     "commands": [
       {
-        "command": "workflow.glsp.diagram.fit",
+        "command": "workflow.diagram.fit",
         "title": "Fit to Screen",
         "category": "Workflow Diagram",
         "enablement": "glsp-workflow-diagram-focused"
       },
       {
-        "command": "workflow.glsp.diagram.center",
+        "command": "workflow.diagram.center",
         "title": "Center selection",
         "category": "Workflow Diagram",
         "enablement": "glsp-workflow-diagram-focused"
       },
       {
-        "command": "workflow.glsp.diagram.layout",
+        "command": "workflow.diagram.layout",
         "title": "Layout diagram",
         "category": "Workflow Diagram",
         "enablement": "glsp-workflow-diagram-focused"
@@ -50,19 +50,19 @@
       {
         "key": "alt+f",
         "mac": "alt+f",
-        "command": "workflow.glsp.diagram.fit",
+        "command": "workflow.diagram.fit",
         "when": "glsp-workflow-diagram-focused"
       },
       {
         "key": "alt+c",
         "mac": "alt+c",
-        "command": "workflow.glsp.diagram.center",
+        "command": "workflow.diagram.center",
         "when": "glsp-workflow-diagram-focused"
       },
       {
         "key": "alt+l",
         "mac": "alt+l",
-        "command": "workflow.glsp.diagram.layout",
+        "command": "workflow.diagram.layout",
         "when": "glsp-workflow-diagram-focused"
       }
     ]

--- a/example/workflow/extension/src/workflow-extension.ts
+++ b/example/workflow/extension/src/workflow-extension.ts
@@ -32,6 +32,6 @@ export function deactivate(): Thenable<void> {
     if (!editorContext) {
         return Promise.resolve(undefined);
     }
-    return editorContext.deactiveGLSPCLient();
+    return editorContext.deactivateGLSPClient();
 }
 

--- a/example/workflow/extension/src/workflow-glsp-diagram-editor-context.ts
+++ b/example/workflow/extension/src/workflow-glsp-diagram-editor-context.ts
@@ -31,13 +31,11 @@ export const SERVER_DIR = join(__dirname, '..', 'server');
 export const JAR_FILE = resolve(join(SERVER_DIR, 'org.eclipse.glsp.example.workflow-0.9.0-SNAPSHOT-glsp.jar'));
 
 export class WorkflowGlspDiagramEditorContext extends GlspDiagramEditorContext {
-
     readonly id = 'glsp.workflow';
     readonly diagramType = 'workflow-diagram';
-    static EXTENSION_PREFIX = 'workflow';
 
-    constructor(context: vscode.ExtensionContext) {
-        super(WorkflowGlspDiagramEditorContext.EXTENSION_PREFIX, context);
+    get extensionPrefix(): string {
+        return 'workflow';
     }
 
     protected getConnectionProvider(): ServerConnectionProvider {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "typescript": "^3.9.7"
   },
   "resolutions": {
-    "**/sprotty": "0.9.0"
+    "**/@eclipse-glsp/client": "0.9.0-next.d9bed812",
+    "**/@eclipse-glsp/protocol": "0.9.0-next.d9bed812",
+    "**/sprotty": "0.10.0-next.0e06051",
+    "**/inversify": "5.0.1"
   },
   "workspaces": [
     "vscode-integration",

--- a/vscode-integration-webview/src/extension-action-handler.ts
+++ b/vscode-integration-webview/src/extension-action-handler.ts
@@ -22,12 +22,12 @@ import { vscodeApi } from 'sprotty-vscode-webview/lib/vscode-api';
  * of the webview. This enables the implementation of action handlers that require access
  * to the vscode API and/or node backend.
  */
-
 export class GLSPVscodeExtensionActionHandler implements IActionHandler, IActionHandlerInitializer {
 
     constructor(protected readonly actionKinds: string[],
         protected readonly diagramIdentifier: SprottyDiagramIdentifier) {
     }
+
     initialize(registry: ActionHandlerRegistry): void {
         this.actionKinds.forEach(kind => registry.register(kind, this));
     }
@@ -37,10 +37,9 @@ export class GLSPVscodeExtensionActionHandler implements IActionHandler, IAction
             const message = {
                 clientId: this.diagramIdentifier.clientId,
                 action,
-                _localDispatch: true
+                __localDispatch: true
             };
             vscodeApi.postMessage(message);
         }
     }
-
 }

--- a/vscode-integration-webview/src/extension-action-handler.ts
+++ b/vscode-integration-webview/src/extension-action-handler.ts
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ ********************************************************************************/
+import { Action, ActionHandlerRegistry, IActionHandler, IActionHandlerInitializer, ICommand } from 'sprotty';
+import { SprottyDiagramIdentifier } from 'sprotty-vscode-webview';
+import { vscodeApi } from 'sprotty-vscode-webview/lib/vscode-api';
+
+/**
+ * Delegates actions that should be handled inside of the glsp vscode extension instead
+ * of the webview. This enables the implementation of action handlers that require access
+ * to the vscode API and/or node backend.
+ */
+
+export class GLSPVscodeExtensionActionHandler implements IActionHandler, IActionHandlerInitializer {
+
+    constructor(protected readonly actionKinds: string[],
+        protected readonly diagramIdentifier: SprottyDiagramIdentifier) {
+    }
+    initialize(registry: ActionHandlerRegistry): void {
+        this.actionKinds.forEach(kind => registry.register(kind, this));
+    }
+
+    handle(action: Action): void | Action | ICommand {
+        if (this.actionKinds.includes(action.kind)) {
+            const message = {
+                clientId: this.diagramIdentifier.clientId,
+                action,
+                _localDispatch: true
+            };
+            vscodeApi.postMessage(message);
+        }
+    }
+
+}

--- a/vscode-integration-webview/src/glsp-starter.ts
+++ b/vscode-integration-webview/src/glsp-starter.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { DiagramServer, TYPES } from '@eclipse-glsp/client';
+import { DiagramServer, NavigateToExternalTargetAction, TYPES } from '@eclipse-glsp/client';
 import { Container } from 'inversify';
 import {
     SprottyDiagramIdentifier,
@@ -23,6 +23,7 @@ import {
     VscodeDiagramWidgetFactory
 } from 'sprotty-vscode-webview';
 
+import { GLSPVscodeExtensionActionHandler } from './extension-action-handler';
 import { GLSPVscodeDiagramWidget } from './glsp-vscode-diagram-widget';
 import { GLSPVscodeDiagramServer } from './glsp-vscode-diagramserver';
 
@@ -37,5 +38,20 @@ export abstract class GLSPStarter extends SprottyStarter {
         container.bind(VscodeDiagramServer).toService(GLSPVscodeDiagramServer);
         container.bind(TYPES.ModelSource).toService(GLSPVscodeDiagramServer);
         container.bind(DiagramServer).toService(GLSPVscodeDiagramServer);
+
+        this.configureExtensionActionHandler(container, diagramIdentifier);
+    }
+
+    protected configureExtensionActionHandler(container: Container, diagramIdentifier: SprottyDiagramIdentifier): void {
+        const extensionActionHandler = new GLSPVscodeExtensionActionHandler(this.extensionActionKinds, diagramIdentifier);
+        container.bind(GLSPVscodeExtensionActionHandler).toConstantValue(extensionActionHandler);
+        container.bind(TYPES.IActionHandlerInitializer).toService(GLSPVscodeExtensionActionHandler);
+    }
+
+    /**
+     *  All kinds of actions that should (also) be delegated to and handled by the vscode extension
+     */
+    protected get extensionActionKinds(): string[] {
+        return [NavigateToExternalTargetAction.KIND];
     }
 }

--- a/vscode-integration-webview/src/glsp-vscode-diagramserver.ts
+++ b/vscode-integration-webview/src/glsp-vscode-diagramserver.ts
@@ -30,7 +30,7 @@ import { inject } from 'inversify';
 import { isActionMessage, VscodeDiagramServer } from 'sprotty-vscode-webview';
 
 export const receivedFromServerProperty = '__receivedFromServer';
-export const localDispatchProperty = '_localDispatch';
+export const localDispatchProperty = '__localDispatch';
 
 export class GLSPVscodeDiagramServer extends VscodeDiagramServer {
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;

--- a/vscode-integration-webview/src/glsp-vscode-diagramserver.ts
+++ b/vscode-integration-webview/src/glsp-vscode-diagramserver.ts
@@ -29,8 +29,8 @@ import { SelectionService } from '@eclipse-glsp/client/lib/features/select/selec
 import { inject } from 'inversify';
 import { isActionMessage, VscodeDiagramServer } from 'sprotty-vscode-webview';
 
-const receivedFromServerProperty = '__receivedFromServer';
-const localDispatchProperty = '_localDispatch';
+export const receivedFromServerProperty = '__receivedFromServer';
+export const localDispatchProperty = '_localDispatch';
 
 export class GLSPVscodeDiagramServer extends VscodeDiagramServer {
     @inject(GLSP_TYPES.SelectionService) protected selectionService: SelectionService;

--- a/vscode-integration/src/action/action.ts
+++ b/vscode-integration/src/action/action.ts
@@ -38,7 +38,6 @@ export class FitToScreenAction implements Action {
         return action !== undefined && action.kind === FitToScreenAction.KIND
             && 'elementIds' in action && 'animate' in action;
     }
-
 }
 
 export class CenterAction implements Action {

--- a/vscode-integration/src/glsp-commands.ts
+++ b/vscode-integration/src/glsp-commands.ts
@@ -27,14 +27,12 @@ export interface GLSPCommandOptions {
     readonly context: vscode.ExtensionContext;
 }
 export namespace GLSPCommand {
-    export const GLSP_DIAGRAM_COMMAND_IDENTIFER = 'glsp.diagram';
-    export const FIT_TO_SCREEN = 'fit';
-    export const CENTER = 'center';
-    export const DELETE = 'delete';
-    export const LAYOUT = 'layout';
+    export const FIT_TO_SCREEN = 'diagram.fit';
+    export const CENTER = 'diagram.center';
+    export const LAYOUT = 'diagram.layout';
 
     export function commandId(extensionPrefix: string, commandKey: string): string {
-        return `${extensionPrefix}.${GLSP_DIAGRAM_COMMAND_IDENTIFER}.${commandKey}`;
+        return `${extensionPrefix}.${commandKey}`;
     }
 
     export function registerActionCommand(options: GLSPCommandOptions): void {

--- a/vscode-integration/src/glsp-diagram-editor-context.ts
+++ b/vscode-integration/src/glsp-diagram-editor-context.ts
@@ -107,6 +107,7 @@ export abstract class GlspDiagramEditorContext extends Disposable {
         this.registerActionCommand(GLSPCommand.CENTER, new CenterAction([]));
         this.registerActionCommand(GLSPCommand.LAYOUT, new LayoutOperation());
     }
+
     /**
      * Register a command that dispatches a new action when triggered.
      * @param command Command id without extension prefix.

--- a/vscode-integration/src/glsp-diagram-editor-provider.ts
+++ b/vscode-integration/src/glsp-diagram-editor-provider.ts
@@ -16,8 +16,6 @@
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-protocol';
 import * as vscode from 'vscode';
 
-import { CenterAction, FitToScreenAction, LayoutOperation } from './action';
-import { GLSPCommand } from './glsp-commands';
 import { GlspDiagramDocument } from './glsp-diagram-document';
 import { GlspDiagramEditorContext } from './glsp-diagram-editor-context';
 import { GLSPWebView, GLSPWebViewRegistry } from './glsp-webview';
@@ -25,40 +23,13 @@ import { disposeAll } from './utils/disposable';
 
 export class GlspDiagramEditorProvider implements vscode.CustomEditorProvider<GlspDiagramDocument> {
     public static VIEW_TYPE = 'glspDiagram';
-    protected webviewRegistry: GLSPWebViewRegistry;
+    readonly webviewRegistry: GLSPWebViewRegistry;
     private _onDidChangeCustomDocument: vscode.EventEmitter<vscode.CustomDocumentEditEvent<GlspDiagramDocument>>;
 
     constructor(protected readonly context: vscode.ExtensionContext,
         protected readonly editorContext: GlspDiagramEditorContext) {
         this.webviewRegistry = new GLSPWebViewRegistry();
         this._onDidChangeCustomDocument = new vscode.EventEmitter<vscode.CustomDocumentEditEvent<GlspDiagramDocument>>();
-        this.registerCommands();
-    }
-
-    protected registerCommands(): void {
-        const options = {
-            context: this.context,
-            registry: this.webviewRegistry,
-            extensionPrefix: this.editorContext.extensionPrefix
-        };
-
-        GLSPCommand.registerActionCommand({
-            action: new FitToScreenAction([]),
-            command: GLSPCommand.FIT_TO_SCREEN,
-            ...options
-        });
-
-        GLSPCommand.registerActionCommand({
-            action: new CenterAction([]),
-            command: GLSPCommand.CENTER,
-            ...options
-        });
-
-        GLSPCommand.registerActionCommand({
-            action: new LayoutOperation(),
-            command: GLSPCommand.LAYOUT,
-            ...options
-        });
     }
 
     get onDidChangeCustomDocument(): vscode.Event<vscode.CustomDocumentEditEvent<GlspDiagramDocument>> {
@@ -99,6 +70,7 @@ export class GlspDiagramEditorProvider implements vscode.CustomEditorProvider<Gl
         const webview = this.editorContext.createWebview(webviewPanel, identifier);
         this.webviewRegistry.add(document.uri, webview);
         webview.addActionHandler(document);
+        this.editorContext.registerActionHandlers(webview);
         document.initialize(identifier, webview);
 
         return webview.connect();

--- a/vscode-integration/src/glsp-webview.ts
+++ b/vscode-integration/src/glsp-webview.ts
@@ -198,7 +198,7 @@ export class GLSPWebView extends Disposable implements ExtensionActionDispatcher
         this.sendToWebview({
             clientId: this.diagramIdentifier.clientId,
             action,
-            _localDispatch: true
+            __localDispatch: true
         });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@
     "@eclipse-glsp/client" "0.9.0-next.d9bed812"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp/client@0.9.0-next.d9bed812":
+"@eclipse-glsp/client@0.9.0-next.d9bed812", "@eclipse-glsp/client@^0.9.0-next.9bc904f3":
   version "0.9.0-next.d9bed812"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.9.0-next.d9bed812.tgz#b96dd5c1c967f1d28263f3836aa8743866a58afd"
   integrity sha512-CYFwwHk7qYmirquOjcEZB5+AOrjAx8xcBECUamllLWWhFZBUxZg6KTwncSgqSoCiv02PbdWSlAMtqy+OjxF3Tg==
@@ -40,24 +40,7 @@
     autocompleter "5.1.0"
     sprotty next
 
-"@eclipse-glsp/client@^0.9.0-next.9bc904f3":
-  version "0.9.0-next.9bc904f3"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.9.0-next.9bc904f3.tgz#f1cd75825090a7c72ccd8a8ed24030b806f6c9dd"
-  integrity sha512-ydAENd+x5kCnv6WCf4aA47FxEecugEQTNxOJVcFIyL83ozry6PopFHiXG3HwRfmZEAdV8ybvPoYz/zBOUJSEhQ==
-  dependencies:
-    "@eclipse-glsp/protocol" "0.9.0-next.9bc904f3"
-    autocompleter "5.1.0"
-    sprotty next
-
-"@eclipse-glsp/protocol@0.9.0-next.9bc904f3":
-  version "0.9.0-next.9bc904f3"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.9.0-next.9bc904f3.tgz#2aae9e69b28729da94a65e292015f972eada860a"
-  integrity sha512-Z685Pa3d84bT8/PhoOL3J2ZYVMazPaffTzh0FggGSTv1raEx2nf3tNxjJVbOrPgpGe1CO6leN1VZ+Lveaq9/Ig==
-  dependencies:
-    uuid "7.0.3"
-    vscode-ws-jsonrpc "0.2.0"
-
-"@eclipse-glsp/protocol@0.9.0-next.d9bed812", "@eclipse-glsp/protocol@next":
+"@eclipse-glsp/protocol@0.9.0-next.d9bed812", "@eclipse-glsp/protocol@^0.9.0-next.9bc904f3":
   version "0.9.0-next.d9bed812"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.9.0-next.d9bed812.tgz#0f28a6917f819f9e424d40019568b38bbd5ddf9f"
   integrity sha512-P9ZnpMQ1Bi1Gykcx7QjXrOaJBoY6WHIhWbd9mqye7kVbBwVr013AVjTJCJL9qPhsJxwfIVBkpTRzOG0bYojDmg==
@@ -3904,15 +3887,10 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-inversify@5.0.1:
+inversify@5.0.1, inversify@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
   integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
-
-inversify@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
-  integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==
 
 invert-kv@^2.0.0:
   version "2.0.0"
@@ -6651,22 +6629,10 @@ sprotty-vscode-webview@0.1.2:
     sprotty-vscode-protocol "^0.0.5"
     vscode-uri "2.1.1"
 
-sprotty@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.9.0.tgz#5644cdb239c43e878705fe76d71ffc73f27cd27b"
-  integrity sha512-kPcXVgspNnMq/ysFFOVfjBkrNK/w9LXSiX1mx3mkEiEVbthjEiKicw+l9uwW9RJH+QvqrK8LrXqEZzKGERUQyA==
-  dependencies:
-    autocompleter "5.1.0"
-    file-saver "2.0.2"
-    inversify "5.0.1"
-    snabbdom "0.7.3"
-    snabbdom-jsx "0.4.2"
-    snabbdom-virtualize "0.7.0"
-
-sprotty@next:
-  version "0.10.0-next.0bb1094"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.10.0-next.0bb1094.tgz#01189a1d956bdcbb3b9ffaa9db943af779a3b21c"
-  integrity sha512-YFsh6UvKAmf8HjnuknHUNX9Jh/PXzr78VmhuimcL+2dnE75Lp7jY2Xa5F2Cwm4TVT7XSIMsh+GmZazLTpzMDhw==
+sprotty@0.10.0-next.0e06051, sprotty@0.9.0, sprotty@next:
+  version "0.10.0-next.0e06051"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.10.0-next.0e06051.tgz#ca76ca2f2056b5df88b47def776825bf36e0cdf6"
+  integrity sha512-iUK9z2IA+aYIakaiYgELEh6vrPBGchy16MiP/RegV1pW3qUPEsTJRf6o3cUuTSWyOc7yL10KkN+iKb04jmD0/g==
   dependencies:
     autocompleter "5.1.0"
     file-saver "2.0.2"


### PR DESCRIPTION
Introduce `GLSPVscodeExtensionActionHandler` that provides the delegation/dispatching of local actions from the webview to the vsode extension. This enables the implementation of action handlers that require access  to the vscode API and/or node backend.

Also:
+ cleanup and centralize command registration into the `GLSPEditorContext` instead of the editor provider.
+ Add `registerActionHandlers()` to `GLSPEditorContext` method that enables the registration of additional extension action handlers in the user space
- Move `extensionPrefix` from constructor into abstract property
- Fix typos