### PR TITLE
Implement basic validation feedback in Problems view

### DIFF
--- a/packages/vscode-integration/src/action/index.ts
+++ b/packages/vscode-integration/src/action/index.ts
@@ -18,3 +18,4 @@ export * from './action-handler';
 export * from './action-dispatcher';
 export * from './action';
 export * from './operation';
+export * from './markers';

--- a/packages/vscode-integration/src/action/markers.ts
+++ b/packages/vscode-integration/src/action/markers.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 EclipseSource and others.
+ * Copyright (c) 2021 EclipseSource and  others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -15,19 +15,18 @@
  ********************************************************************************/
 import { Action } from 'sprotty-vscode-protocol';
 
-/**
- * Used to locally intercept and handle actions in the VS Code extension.
- */
-export interface ExtensionActionHandler {
+export interface Marker {
+    readonly label: string;
+    readonly description: string;
+    readonly elementId: string;
+    readonly kind: 'info' | 'warning' | 'error';
+}
 
-    /**
-     * List of action names that the action handler will intercept.
-     */
-    readonly kinds: string[];
+export class SetMarkersAction implements Action {
+    static readonly KIND = 'setMarkers';
+    constructor(public readonly markers: Marker[], public readonly kind = SetMarkersAction.KIND) { }
 
-    /**
-     * @returns true when the action should be further progagated to the glsp server or the
-     * webview
-     */
-    handleAction(action: Action): Thenable<boolean>;
+    static is(action?: Action): action is SetMarkersAction {
+        return action !== undefined && action.kind === SetMarkersAction.KIND && 'markers' in action;
+    }
 }

--- a/packages/vscode-integration/src/glsp-diagram-editor-provider.ts
+++ b/packages/vscode-integration/src/glsp-diagram-editor-provider.ts
@@ -51,6 +51,7 @@ export class GlspDiagramEditorProvider implements vscode.CustomEditorProvider<Gl
         Thenable<vscode.CustomDocumentBackup> {
         return document.backup(context.destination, cancellation);
     }
+
     async openCustomDocument(uri: vscode.Uri, openContext: vscode.CustomDocumentOpenContext, token: vscode.CancellationToken): Promise<GlspDiagramDocument> {
         const document = await GlspDiagramDocument.create(uri, openContext.backupId);
 
@@ -65,6 +66,7 @@ export class GlspDiagramEditorProvider implements vscode.CustomEditorProvider<Gl
         document.onDidDispose(() => disposeAll(listeners));
         return document;
     }
+
     resolveCustomEditor(document: GlspDiagramDocument, webviewPanel: vscode.WebviewPanel, token: vscode.CancellationToken): void | Thenable<void> {
         const identifier = this.createDiagramIdentifier(document);
         const webview = this.editorContext.createWebview(webviewPanel, identifier);

--- a/packages/vscode-integration/src/glsp-webview.ts
+++ b/packages/vscode-integration/src/glsp-webview.ts
@@ -76,6 +76,9 @@ export interface GLSPWebviewOptions {
     scriptUri: vscode.Uri;
     webviewPanel: vscode.WebviewPanel;
 }
+
+export type GLSPWebviewMessage = ActionMessage | SprottyDiagramIdentifier | ResponseMessage;
+
 export class GLSPWebView extends Disposable implements ExtensionActionDispatcher {
     static viewCount = 0;
 
@@ -161,7 +164,7 @@ export class GLSPWebView extends Disposable implements ExtensionActionDispatcher
         vscode.commands.executeCommand('setContext', 'glsp-' + this.diagramIdentifier.diagramType + '-focused', isActive);
     }
 
-    protected async sendToWebview(message: any): Promise<void> {
+    protected async sendToWebview(message: GLSPWebviewMessage): Promise<void> {
         if (this.diagramPanel.visible) {
             if (isActionMessage(message)) {
                 const shouldForwardToWebview = await this.handleLocally(message.action);
@@ -202,7 +205,7 @@ export class GLSPWebView extends Disposable implements ExtensionActionDispatcher
             clientId: this.diagramIdentifier.clientId,
             action,
             __localDispatch: true
-        });
+        } as ActionMessage); // TODO: Type Messages properly so that this casting isn't necessary
     }
 
     /**


### PR DESCRIPTION
This PR addresses eclipse-glsp/glsp/issues/206 by implementing a basic feedback for GLSP markers in the VSCode problems view:

- Add `SetMarkersAction`.
- Let custom document handle `setMarkers` actions by setting diagnostics.
- Fix behaviour where messages from GLSP server were put into all webview message queues, instead of only those that are related to the server message.

part-of eclipse-glsp/glsp/issues/206.