### PR TITLE
#377 Update to latest glsp-config version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,9 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "engines": {
+    "yarn": ">=1.7.0 <2.x.x"
+  },
   "scripts": {
     "prepare": "lerna run prepare",
     "watch": "lerna run --parallel watch",
@@ -13,7 +16,7 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.54.0",
-    "@eclipse-glsp/config": "0.9.0-next.9648217c",
+    "@eclipse-glsp/config": "0.9.0-next.0e05932b",
     "rimraf": "^2.6.3",
     "lerna": "^2.2.0",
     "mvn-artifact-download": "5.1.0",

--- a/packages/vscode-integration/src/glsp-vscode-connector.ts
+++ b/packages/vscode-integration/src/glsp-vscode-connector.ts
@@ -364,6 +364,7 @@ export class GlspVscodeConnector<D extends vscode.CustomDocument = vscode.Custom
         }
 
         if (origin === MessageOrigin.CLIENT) {
+            // eslint-disable-next-line max-len
             // Do not propagate action if it comes from client to avoid an infinite loop, as both, client and server will mirror the Selection action
             return { processedMessage: undefined, messageChanged: true };
         } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,19 +40,19 @@
     autocompleter "5.1.0"
     sprotty next
 
-"@eclipse-glsp/config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.9648217c.tgz#4cd4ed484aa8e30cfd2bfa6196c8cddd3fd3ef67"
-  integrity sha512-u7Xu0//rKYrr+89pQYtRR86ZQt1Ey+m/nwY7OeowAJaeZdE/0fnaBUA71FTP86qS/Sht9Ec+GVGpQh6+T2v3mw==
+"@eclipse-glsp/config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/config/-/config-0.9.0-next.0e05932b.tgz#e491200537236d39d07b6c44640748a865f311f9"
+  integrity sha512-2umAyVWSyazzNNgIvvqci1vwTjvItLLBaLldaG4nMiSzjPS4bDTf1Y4etNtb6pdmtZ2IgJcFg03bXBWOGzCYvw==
   dependencies:
-    "@eclipse-glsp/eslint-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/prettier-config" "0.9.0-next.9648217c"
-    "@eclipse-glsp/ts-config" "0.9.0-next.9648217c"
+    "@eclipse-glsp/eslint-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/prettier-config" "0.9.0-next.0e05932b"
+    "@eclipse-glsp/ts-config" "0.9.0-next.0e05932b"
 
-"@eclipse-glsp/eslint-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.9648217c.tgz#5f9e12653f646bebe7ae0a7a4fe00bfb187b8cb3"
-  integrity sha512-QRotLPdimHm70NWrr1TabJOgEEGHKqtt4RRtKUxsgjLwLEYKPKi2vnz0Oc9RPhCVoTsraOuzpyr/1jWJZY0grw==
+"@eclipse-glsp/eslint-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-0.9.0-next.0e05932b.tgz#8ed0092ed55027f18fc886c99fed4f84800f84ea"
+  integrity sha512-wBcqs/ncUSirIjiewoGWvwlAYBJjUUwNu5+vOlNWYsO1xW4xu+tuuIJ5jolmMcHpONa/TQws1B7MB1oLw3cWlA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.32.0"
     "@typescript-eslint/parser" "^4.32.0"
@@ -62,10 +62,10 @@
     eslint-plugin-import "^2.24.2"
     eslint-plugin-no-null "^1.0.2"
 
-"@eclipse-glsp/prettier-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.9648217c.tgz#d346ca86f59b5dc17f2721d31a1dda67864da783"
-  integrity sha512-GKpJp4HrDw66dzqA1RSPt1AjXFSEhtlHi10pSw3BfBqoRrXstTSwIOYwK0oAFz6R4ORE3WL5r5O4kQaS/CnANQ==
+"@eclipse-glsp/prettier-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/prettier-config/-/prettier-config-0.9.0-next.0e05932b.tgz#83469b5638673418cbb901df9710e31df1ab7f4b"
+  integrity sha512-xcpZ8qxhSAMocFKnKMRsGmMdFXUb9bvN5U2qBZJNqn4Oe5EB7hpJNkugUXHZODo15P4WgkSZXS9vPjCus90wqQ==
 
 "@eclipse-glsp/protocol@0.9.0-next.7d7aab40", "@eclipse-glsp/protocol@next":
   version "0.9.0-next.7d7aab40"
@@ -75,10 +75,10 @@
     uuid "7.0.3"
     vscode-ws-jsonrpc "0.2.0"
 
-"@eclipse-glsp/ts-config@0.9.0-next.9648217c":
-  version "0.9.0-next.9648217c"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.9648217c.tgz#20a07d7105d2854ae838f7be95242fe6158ea80b"
-  integrity sha512-ZZ2HQ7S5p4EELJRxpzHxyd0hitH9y54Uf54E1RPwQPDcWR7Z1s7SK6y/CoRBs2SQ6vzEjG2WV/j21ULt34G8rQ==
+"@eclipse-glsp/ts-config@0.9.0-next.0e05932b":
+  version "0.9.0-next.0e05932b"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ts-config/-/ts-config-0.9.0-next.0e05932b.tgz#6be3648264e4c53db88946b7e7830e983b4f7845"
+  integrity sha512-sjlIirOmnsXrdS1csbcBW2M25UjPzMt50aYwoKbjTsC0u3SJFxXXgmy4ZJwtxdDN90gsBntRT2G/3iT/e7CvNg==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"


### PR DESCRIPTION
Update to latest glsp-config version to consume eclipse-glsp/glsp#405
(Update eslint-config to display formatting linting issues that get autofixed by prettier as warning)
(This is possible for all formatting linting rules except the "indent" rule. This rule has to be disabled. Prettier uses a dynamic indent size (e.g. spread objects (...) are formatted with two additional spaces, whereas es-lint only supports a static/fixed indent size. This causes unfixable warnings if the rule is activated. Prettier will still format and indent all lines correctly on save.

This means the developer should now get direct feedback in the editor again if there is a formatting issue like using " instead of ', multiple consecutive empty lines, missing semicolons etc.

Also:

Align yarn version range with Theia
Add prettier as default formatter for "javascriptreact" (.jsx files).