### PR TITLE
#516 Fix invalid declaration `RequestTypeHintsAction` in diagram widget

### DIFF
--- a/packages/vscode-integration-webview/src/glsp-vscode-diagram-widget.ts
+++ b/packages/vscode-integration-webview/src/glsp-vscode-diagram-widget.ts
@@ -30,7 +30,7 @@ export abstract class GLSPVscodeDiagramWidget extends VscodeDiagramWidget {
             })
         );
 
-        this.actionDispatcher.dispatch(new RequestTypeHintsAction(this.diagramIdentifier.diagramType));
+        this.actionDispatcher.dispatch(new RequestTypeHintsAction());
         this.actionDispatcher.dispatch(new EnableToolPaletteAction());
     }
 }


### PR DESCRIPTION
The `RequestTypeHints` action no longer supports a `diagramType` property. If a string is passed in the constructor is is used as `RequestId` instead. 
Since we dispatch the `RequestTypeHints` action as plain action notification (i.e. not with `actionDispatcher.request()`)  it will not be handled properly and the client never receives the `SetTypeHintsAction` result. 
Fixes eclipse-glsp/glsp/issues/516