### PR TITLE
Fix example build (WebPack & Server download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Clone this repository and build the VSCode integration packages:
 yarn install
 ```
 
+Additionally you can download a precompiled version of the Workflow Diagram Server:
+
+```bash
+yarn --cwd example/workflow/extension download:Server
+```
+
+> The downloaded server will be launched automatically by the extension. To debug or modify the server and run it separately: see the instructions below.
+
 Now you can start the VSCode extension by opening this repository in VSCode and executing the "Workflow GLSP Example Extension" launch configuration, provided with this project.
 
 ### How to start the Workflow Diagram example server from the sources

--- a/example/workflow/webview/package.json
+++ b/example/workflow/webview/package.json
@@ -43,7 +43,7 @@
     "yargs": "^12.0.5"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && webpack --mode=development",
     "clean": "rimraf lib tsconfig.tsbuildinfo ",
     "lint": "eslint --ext .ts,.tsx ./src",
     "lint:ci": "yarn lint -o eslint.xml -f checkstyle",


### PR DESCRIPTION
It seems that https://github.com/eclipse-glsp/glsp-vscode-integration/pull/29 introduced some regressions:
* the WebPack build is no longer called, hence the webview.js is not created and copied into ```extension/pack``` directory
* the prebuild GLSP example server is no longer downloaded during the extension build (which is better I think): I added an instruction in the README to download it manually