### PR TITLE
feat: adjust server startup to use autoassigned ports

### DIFF
--- a/example/workflow/extension/src/workflow-extension.ts
+++ b/example/workflow/extension/src/workflow-extension.ts
@@ -15,9 +15,9 @@
  ********************************************************************************/
 import { GlspVscodeConnector, NavigateAction } from '@eclipse-glsp/vscode-integration';
 import {
-    configureDefaultCommands,
     GlspServerLauncher,
-    SocketGlspVscodeServer
+    SocketGlspVscodeServer,
+    configureDefaultCommands
 } from '@eclipse-glsp/vscode-integration/lib/quickstart-components';
 import * as path from 'path';
 import * as process from 'process';
@@ -26,7 +26,7 @@ import * as vscode from 'vscode';
 import * as config from './server-config.json';
 import WorkflowEditorProvider from './workflow-editor-provider';
 
-const DEFAULT_SERVER_PORT = '5007';
+const DEFAULT_SERVER_PORT = '0';
 const { version, isSnapShot } = config;
 const JAVA_EXECUTABLE = path.join(
     __dirname,
@@ -35,8 +35,9 @@ const JAVA_EXECUTABLE = path.join(
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     // Start server process using quickstart component
+    let serverProcess: GlspServerLauncher | undefined;
     if (process.env.GLSP_SERVER_DEBUG !== 'true') {
-        const serverProcess = new GlspServerLauncher({
+        serverProcess = new GlspServerLauncher({
             executable: JAVA_EXECUTABLE,
             socketConnectionOptions: { port: JSON.parse(process.env.GLSP_SERVER_PORT || DEFAULT_SERVER_PORT) },
             additionalArgs: ['--fileLog', 'true', '--logDir', path.join(__dirname, '../server')],
@@ -51,9 +52,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const workflowServer = new SocketGlspVscodeServer({
         clientId: 'glsp.workflow',
         clientName: 'workflow',
-        serverPort: JSON.parse(process.env.GLSP_SERVER_PORT || DEFAULT_SERVER_PORT)
+        serverPort: serverProcess?.getPort() || JSON.parse(process.env.GLSP_SERVER_PORT || DEFAULT_SERVER_PORT)
     });
-
     // Initialize GLSP-VSCode connector with server wrapper
     const glspVscodeConnector = new GlspVscodeConnector({
         server: workflowServer,

--- a/packages/vscode-integration/README.md
+++ b/packages/vscode-integration/README.md
@@ -54,7 +54,7 @@ import { GlspServerLauncher } from '@eclipse-glsp/vscode-integration/lib/quickst
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const serverProcess = new GlspServerLauncher({
         jarPath: '/your/path/to/server.jar',
-        serverPort: 5007
+        serverPort: 0 // for auto port
     });
     context.subscriptions.push(serverProcess);
     await serverProcess.start();
@@ -82,7 +82,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const workflowServer = new SocketGlspVscodeServer({
         clientId: 'some.client.id',
         clientName: 'SomeClientName',
-        serverPort: 5007
+        serverPort: serverProcess.getPort()
     });
 
     const glspVscodeConnector = new GlspVscodeConnector({ server: workflowServer });

--- a/packages/vscode-integration/src/quickstart-components/glsp-server-launcher.ts
+++ b/packages/vscode-integration/src/quickstart-components/glsp-server-launcher.ts
@@ -74,6 +74,13 @@ export class GlspServerLauncher implements vscode.Disposable {
 
             process.stdout.on('data', data => {
                 if (data.toString().includes(START_UP_COMPLETE_MSG)) {
+                    const port = this.getPortFromStartupMessage(data.toString());
+                    if (port) {
+                        console.log(`GLSP server started on port ${port}`);
+                        this.options.socketConnectionOptions.port = port;
+                    } else {
+                        throw new Error('Could not find listening port in startup message of GLSP server!');
+                    }
                     resolve();
                 }
 
@@ -115,6 +122,14 @@ export class GlspServerLauncher implements vscode.Disposable {
         return childProcess.spawn('node', args);
     }
 
+    protected getPortFromStartupMessage(message: string): number | undefined {
+        if (message.includes(START_UP_COMPLETE_MSG)) {
+            const port = message.substring(message.lastIndexOf(':') + 1);
+            return parseInt(port, 10);
+        }
+        return undefined;
+    }
+
     protected handleStdoutData(data: string | Buffer): void {
         if (this.options.logging) {
             console.log('GLSP-Server:', data.toString());
@@ -133,6 +148,10 @@ export class GlspServerLauncher implements vscode.Disposable {
         }
 
         throw error;
+    }
+
+    getPort(): number {
+        return this.options.socketConnectionOptions.port;
     }
 
     /**


### PR DESCRIPTION
All our GLSP server implementations are now capable of port autoassignment. The listening port is printed to STDOUT when the server is launched and has to be parsed by clients.

This patch adjusts the vscode integration to use the new port autoassignment.

Part of eclipse-glsp/glsp/issues/965