### PR TITLE
GLSP-1006: Improve DirtyStateEventHandling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
       ],
       "outFiles": [
         "${workspaceFolder}/example/workflow/extension/lib/*.js",
-        "${workspaceFolder}/vscode-integration/lib/**/*.js"
+        "${workspaceFolder}/packages/vscode-integration/lib/**/*.js"
       ],
       "sourceMaps": true
     },
@@ -30,7 +30,7 @@
       ],
       "outFiles": [
         "${workspaceFolder}/example/workflow/extension/lib/*.js",
-        "${workspaceFolder}/vscode-integration/lib/**/*.js"
+        "${workspaceFolder}/packages/vscode-integration/lib/**/*.js"
       ],
       "sourceMaps": true,
       "env": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mvn-artifact-download": "5.1.0"
   },
   "engines": {
-    "node": ">=14.18.0",
+    "node": ">=16.11.0",
     "yarn": ">=1.7.0 <2.x.x"
   }
 }

--- a/packages/vscode-integration/src/quickstart-components/glsp-editor-provider.ts
+++ b/packages/vscode-integration/src/quickstart-components/glsp-editor-provider.ts
@@ -32,7 +32,7 @@ export abstract class GlspEditorProvider implements vscode.CustomEditorProvider 
     /** Used to generate continuous and unique clientIds - TODO: consider replacing this with uuid. */
     private viewCount = 0;
 
-    onDidChangeCustomDocument: vscode.Event<vscode.CustomDocumentContentChangeEvent<vscode.CustomDocument>>;
+    onDidChangeCustomDocument: vscode.Event<vscode.CustomDocumentEditEvent> | vscode.Event<vscode.CustomDocumentContentChangeEvent>;
 
     constructor(protected readonly glspVscodeConnector: GlspVscodeConnector) {
         this.onDidChangeCustomDocument = glspVscodeConnector.onDidChangeCustomDocument;


### PR DESCRIPTION
Update the `onDidChangeCustomDocument` event emitter so that it is also possible to send events for dirty changes that have not been triggered by an edit/operation. Update `handleDirtyStateMethod` to  also emit a change event for reasons other than `operation`.

Also: Fix invalid source map paths of launch configs 
Fixes https://github.com/eclipse-glsp/glsp/issues/1006