### PR TITLE
Fix semantics of increment vs UpdateProgressAction

### DIFF
--- a/packages/vscode-integration/src/common/glsp-vscode-connector.ts
+++ b/packages/vscode-integration/src/common/glsp-vscode-connector.ts
@@ -53,10 +53,10 @@ export type SelectionState = Omit<SelectAction, 'kind'>;
 interface ProgressReporter {
     deferred: Deferred<void>;
     progress: vscode.Progress<{
-        message?: string | undefined;
-        increment?: number | undefined;
+        message?: string;
+        increment?: number;
     }>;
-    currentPercentage?: number | undefined;
+    currentPercentage?: number;
 }
 
 /**


### PR DESCRIPTION
Sorry, while testing with a Java implementation of the progress reporting, I encountered a difference between Theia and VS Code:

VS Code expects increments relative to the previously reported progress. In GLSP UpdateProgressAction however we expect the full percentage in the action message. Thus, we need to make some adjustments before it over to the VS Code API.