### PR TITLE
GLSP-1254 Fix client-server action forwarding

### DIFF
--- a/example/workflow/extension/package.json
+++ b/example/workflow/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-vscode-example",
   "displayName": "Workflow GLSP Example",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "private": "true",
   "description": "An example graphical language used for modeling workflows",
   "categories": [
@@ -194,16 +194,16 @@
     "onStartupFinished"
   ],
   "devDependencies": {
-    "@eclipse-glsp-examples/workflow-server": "2.1.0",
-    "@eclipse-glsp-examples/workflow-server-bundled": "2.1.0",
-    "@eclipse-glsp/vscode-integration": "^2.1.0",
+    "@eclipse-glsp-examples/workflow-server": "next",
+    "@eclipse-glsp-examples/workflow-server-bundled": "next",
+    "@eclipse-glsp/vscode-integration": "2.2.0-next",
     "@vscode/vsce": "^2.19.0",
     "copy-webpack-plugin": "^11.0.0",
     "ts-loader": "^9.4.4",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4",
     "webpack-merge": "^5.9.0",
-    "workflow-glsp-webview": "^2.1.0"
+    "workflow-glsp-webview": "2.2.0-next"
   },
   "engines": {
     "vscode": "^1.54.0"

--- a/example/workflow/extension/src/workflow-extension.ts
+++ b/example/workflow/extension/src/workflow-extension.ts
@@ -95,13 +95,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     context.subscriptions.push(
         vscode.commands.registerCommand('workflow.goToNextNode', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('next'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('next'));
         }),
         vscode.commands.registerCommand('workflow.goToPreviousNode', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('previous'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('previous'));
         }),
         vscode.commands.registerCommand('workflow.showDocumentation', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('documentation'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('documentation'));
         })
     );
 }

--- a/example/workflow/web-extension/package.json
+++ b/example/workflow/web-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-vscode-example-web",
   "displayName": "Workflow GLSP Example (Web)",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "private": "true",
   "description": "An example graphical language used for modeling workflows",
   "categories": [
@@ -195,15 +195,15 @@
     "onStartupFinished"
   ],
   "devDependencies": {
-    "@eclipse-glsp-examples/workflow-server": "2.1.0",
-    "@eclipse-glsp/vscode-integration": "^2.1.0",
+    "@eclipse-glsp-examples/workflow-server": "next",
+    "@eclipse-glsp/vscode-integration": "2.2.0-next",
     "@types/node": "16.x",
     "@vscode/vsce": "^2.19.0",
     "copy-webpack-plugin": "^11.0.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-merge": "^5.9.0",
-    "workflow-glsp-webview": "^2.1.0"
+    "workflow-glsp-webview": "2.2.0-next"
   },
   "engines": {
     "vscode": "^1.54.0"

--- a/example/workflow/web-extension/src/workflow-extension.ts
+++ b/example/workflow/web-extension/src/workflow-extension.ts
@@ -67,13 +67,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     context.subscriptions.push(
         vscode.commands.registerCommand('workflow.goToNextNode', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('next'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('next'));
         }),
         vscode.commands.registerCommand('workflow.goToPreviousNode', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('previous'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('previous'));
         }),
         vscode.commands.registerCommand('workflow.showDocumentation', () => {
-            glspVscodeConnector.sendActionToActiveClient(NavigateAction.create('documentation'));
+            glspVscodeConnector.dispatchAction(NavigateAction.create('documentation'));
         })
     );
 }

--- a/example/workflow/webview/package.json
+++ b/example/workflow/webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-glsp-webview",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "private": "true",
   "description": "Example of the Workflow GLSP diagram in a VS Code extensions (WebView part)",
   "keywords": [
@@ -38,8 +38,8 @@
     "watch": "tsc -w"
   },
   "devDependencies": {
-    "@eclipse-glsp-examples/workflow-glsp": "2.1.0",
-    "@eclipse-glsp/vscode-integration-webview": "^2.1.0",
+    "@eclipse-glsp-examples/workflow-glsp": "next",
+    "@eclipse-glsp/vscode-integration-webview": "2.2.0-next",
     "@vscode/codicons": "^0.0.25",
     "circular-dependency-plugin": "^5.2.2",
     "css-loader": "^6.7.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "npmClient": "yarn",
   "command": {
     "run": {

--- a/packages/vscode-integration-webview/package.json
+++ b/packages/vscode-integration-webview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-glsp/vscode-integration-webview",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "description": "Integration of a GLSP diagram in a VS Code extensions (WebView part)",
   "keywords": [
     "vscode",
@@ -42,7 +42,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/client": "2.1.0",
+    "@eclipse-glsp/client": "next",
     "vscode-messenger-webview": "^0.4.5"
   },
   "devDependencies": {

--- a/packages/vscode-integration-webview/src/features/copyPaste/copy-paste-module.ts
+++ b/packages/vscode-integration-webview/src/features/copyPaste/copy-paste-module.ts
@@ -14,16 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import {
-    FeatureModule,
-    ICopyPasteHandler,
-    RequestClipboardDataAction,
-    SetClipboardDataAction,
-    TYPES,
-    bindAsService,
-    copyPasteModule
-} from '@eclipse-glsp/client';
-import { ExtensionActionKind } from '../default/extension-action-handler';
+import { FeatureModule, ICopyPasteHandler, TYPES, bindAsService, copyPasteModule } from '@eclipse-glsp/client';
 import { CopyPasteHandlerProvider, CopyPasteStartup } from './copy-paste-startup';
 
 export const vscodeCopyPasteModule = new FeatureModule(
@@ -32,8 +23,6 @@ export const vscodeCopyPasteModule = new FeatureModule(
             ctx => () => new Promise<ICopyPasteHandler>(resolve => resolve(ctx.container.get<ICopyPasteHandler>(TYPES.ICopyPasteHandler)))
         );
         bindAsService(bind, TYPES.IDiagramStartup, CopyPasteStartup);
-        bind(ExtensionActionKind).toConstantValue(RequestClipboardDataAction.KIND);
-        bind(ExtensionActionKind).toConstantValue(SetClipboardDataAction.KIND);
     },
     { requires: copyPasteModule }
 );

--- a/packages/vscode-integration-webview/src/features/default/default-module.ts
+++ b/packages/vscode-integration-webview/src/features/default/default-module.ts
@@ -14,17 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { FeatureModule, GLSPModelSource, SelectAction, TYPES, bindAsService, defaultModule } from '@eclipse-glsp/client';
+import { FeatureModule, SelectAction, TYPES, bindAsService, defaultModule } from '@eclipse-glsp/client';
 import { GLSPDiagramWidget, GLSPDiagramWidgetFactory } from '../../glsp-diagram-widget';
 import { ExtensionActionKind, HostExtensionActionHandler } from './extension-action-handler';
-import { VsCodeGLSPModelSource } from './vscode-glsp-modelsource';
 
 export const vscodeDefaultModule = new FeatureModule(
-    (bind, _unbind, _isBound, rebind) => {
+    bind => {
         bind(GLSPDiagramWidget).toSelf().inSingletonScope();
         bind(GLSPDiagramWidgetFactory).toFactory(context => () => context.container.get<GLSPDiagramWidget>(GLSPDiagramWidget));
-        bind(VsCodeGLSPModelSource).toSelf().inSingletonScope();
-        rebind(GLSPModelSource).toService(VsCodeGLSPModelSource);
         bindAsService(bind, TYPES.IActionHandlerInitializer, HostExtensionActionHandler);
         bind(ExtensionActionKind).toConstantValue(SelectAction.KIND);
     },

--- a/packages/vscode-integration-webview/src/features/default/extension-action-handler.ts
+++ b/packages/vscode-integration-webview/src/features/default/extension-action-handler.ts
@@ -64,8 +64,7 @@ export class HostExtensionActionHandler implements IActionHandler, IActionHandle
         if (this.actionKinds.includes(action.kind)) {
             const message = {
                 clientId: this.diagramOptions.clientId,
-                action,
-                __localDispatch: true
+                action
             };
             this.glspClient?.sendActionMessage(message);
         }

--- a/packages/vscode-integration-webview/src/features/default/vscode-glsp-modelsource.ts
+++ b/packages/vscode-integration-webview/src/features/default/vscode-glsp-modelsource.ts
@@ -13,18 +13,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { Action, ActionMessage, GLSPModelSource, ServerAction } from '@eclipse-glsp/client';
+/* eslint-disable deprecation/deprecation */
+import { Action, GLSPModelSource } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 
 /**
  * A helper interface that allows the webview to mark actions that have been received directly from the vscode extension
  * (i.e. they are not forwarded to the GLSP Server).
+ *
+ * @deprecated The concept of marking actions as locally dispatched `ExtensionAction`s is no longer necessary and usage is discouraged.
  */
 export interface ExtensionAction extends Action {
     __localDispatch: true;
 }
 
 export namespace ExtensionAction {
+    /**
+     * @deprecated The concept of marking actions as locally dispatched `ExtensionAction`s is no longer necessary and usage is discouraged.
+     * */
     export function is(object: unknown): object is ExtensionAction {
         return Action.is(object) && '__localDispatch' in object && object.__localDispatch === true;
     }
@@ -32,6 +38,8 @@ export namespace ExtensionAction {
     /**
      * Mark the given action as {@link ServerAction} by attaching the "_receivedFromServer" property
      * @param action The action that should be marked as server action
+     *
+     * @deprecated The concept of marking actions as locally dispatched `ExtensionAction`s is no longer necessary and usage is discouraged.
      */
     export function mark(action: Action): void {
         (action as ExtensionAction).__localDispatch = true;
@@ -41,23 +49,8 @@ export namespace ExtensionAction {
 /**
  * Customization of the default {@link GLSPModelSource} for the vscode integration.
  * Also takes locally dispatched actions (i.e. actions that are originating from or intended for the host extension) into consideration.
+ *
+ * @deprecated A customized model source is no longer necessary. Use the default {@link GLSPModelSource} instead.
  */
 @injectable()
-export class VsCodeGLSPModelSource extends GLSPModelSource {
-    protected override messageReceived(message: ActionMessage): void {
-        if (this.clientId !== message.clientId) {
-            return;
-        }
-        this.checkMessageOrigin(message);
-        const action = message.action;
-        this.logger.log(this, 'receiving', action);
-        this.actionDispatcher.dispatch(action);
-    }
-
-    protected checkMessageOrigin(message: ActionMessage): void {
-        const isLocalDispatch = (message as any)['__localDispatch'] ?? false;
-        if (!isLocalDispatch) {
-            ServerAction.mark(message.action);
-        }
-    }
-}
+export class VsCodeGLSPModelSource extends GLSPModelSource {}

--- a/packages/vscode-integration/package.json
+++ b/packages/vscode-integration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eclipse-glsp/vscode-integration",
   "displayName": "GLSP VSCode Integration",
-  "version": "2.1.0",
+  "version": "2.2.0-next",
   "description": "Glue code to integrate GLSP diagrams in VSCode extensions (extension part)",
   "keywords": [
     "eclipse",
@@ -47,13 +47,12 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@eclipse-glsp/protocol": "2.1.0",
+    "@eclipse-glsp/protocol": "next",
     "vscode-jsonrpc": "^8.0.2",
     "vscode-messenger": "^0.4.5",
     "ws": "^8.13.0"
   },
   "devDependencies": {
-    "@types/node": "^12.12.0",
     "@types/vscode": "^1.54.0",
     "@types/ws": "^8.5.4"
   },

--- a/packages/vscode-integration/src/common/glsp-vscode-connector.ts
+++ b/packages/vscode-integration/src/common/glsp-vscode-connector.ts
@@ -269,6 +269,7 @@ export class GlspVscodeConnector<D extends vscode.CustomDocument = vscode.Custom
     dispatchAction(action: Action, clientId?: string): void {
         const client = clientId ? this.clientMap.get(clientId) : this.getActiveClient();
         if (!client) {
+            console.warn('Could not dispatch action: No client found for clientId or no active client found.', action);
             return;
         }
         const message = { clientId: client.clientId, action };

--- a/packages/vscode-integration/src/common/quickstart-components/configuration-util.ts
+++ b/packages/vscode-integration/src/common/quickstart-components/configuration-util.ts
@@ -45,19 +45,19 @@ export function configureDefaultCommands(context: CommandContext): void {
 
     extensionContext.subscriptions.push(
         vscode.commands.registerCommand(`${diagramPrefix}.fit`, () => {
-            connector.sendActionToActiveClient(FitToScreenAction.create(selectionState?.selectedElementsIDs ?? []));
+            connector.dispatchAction(FitToScreenAction.create(selectionState?.selectedElementsIDs ?? []));
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.center`, () => {
-            connector.sendActionToActiveClient(CenterAction.create(selectionState?.selectedElementsIDs ?? []));
+            connector.dispatchAction(CenterAction.create(selectionState?.selectedElementsIDs ?? []));
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.layout`, () => {
-            connector.sendActionToActiveClient(LayoutOperation.create([]));
+            connector.dispatchAction(LayoutOperation.create([]));
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.selectAll`, () => {
-            connector.sendActionToActiveClient(SelectAllAction.create());
+            connector.dispatchAction(SelectAllAction.create());
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.exportAsSVG`, () => {
-            connector.sendActionToActiveClient(RequestExportSvgAction.create());
+            connector.dispatchAction(RequestExportSvgAction.create());
         })
     );
 

--- a/packages/vscode-integration/src/common/quickstart-components/webview-endpoint.ts
+++ b/packages/vscode-integration/src/common/quickstart-components/webview-endpoint.ts
@@ -140,8 +140,6 @@ export class WebviewEndpoint implements Disposable {
     }
 
     sendMessage(actionMessage: ActionMessage): void {
-        // Attach a property to mark the actionMessage as locally dispatched (i.e. not received from the serer)
-        (actionMessage as any).__localDispatch = true;
         this.messenger.sendNotification(ActionMessageNotification, this.messageParticipant, actionMessage);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,26 +220,26 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eclipse-glsp-examples/workflow-glsp@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.1.0.tgz#4ff8660dce094a2ad31e7034eae3a220bbfb80cd"
-  integrity sha512-uHn8dRutEO00F7KsZZEhRBnu4J6gRkFB4yTeVimtBik5FXld+z+zY7AfSfrfz+AJ9Fu+aEIZyyzHASmlWLvXOA==
+"@eclipse-glsp-examples/workflow-glsp@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-2.3.0-next.309.tgz#d30a23276b5759f6601a3f64cb34392ae2ef468f"
+  integrity sha512-k7Ds2IEnYQLxHk59L3q3/MYpuYXm93KzIQymvEKrSCI5blyT8fnjZR9a4buIeJAa5P87eAM5yGnq0aQuWUX/oA==
   dependencies:
-    "@eclipse-glsp/client" "2.1.0"
+    "@eclipse-glsp/client" "2.3.0-next.309+b90a740"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp-examples/workflow-server-bundled@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-2.1.0.tgz#02842cf9e4ca777052be0b338d90aeda180f17d3"
-  integrity sha512-eJGZZfm2jkl99RJhjrOB5qN5cxn2a7M2vzHNtyALxrmtqQET16gIy9H9h2VGq2bHqv2ZDWNsuDW1nKt17EltpQ==
+"@eclipse-glsp-examples/workflow-server-bundled@next":
+  version "2.2.0-next.83"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server-bundled/-/workflow-server-bundled-2.2.0-next.83.tgz#f19bb19a9d6d1d64e63f3428b9af1a8b49c26330"
+  integrity sha512-3eYaEn/ZVnG1O0o+oXU6lNtTFSx0ZYur4IgN6ak2rOBI0NPIyTUY6MpQEJgbNqXm7yd4Hdu3yjMn97w1CXHKjQ==
 
-"@eclipse-glsp-examples/workflow-server@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.1.0.tgz#63af096a4138677c0f50359d44c8eeed3cfc7aed"
-  integrity sha512-VBcVJY8mmI6nsLvND2x0LX/+Osi6JpQ+eGok7tbbcr3QZfbG83EcUiKCt2xlzkBaaoTlo6UQyelqN6W8MQe+DQ==
+"@eclipse-glsp-examples/workflow-server@next":
+  version "2.2.0-next.83"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-server/-/workflow-server-2.2.0-next.83.tgz#f8362f2dfd5a987da2a7a8e4e9ec2b8e3ee9a291"
+  integrity sha512-EniuTUc6HhrrpcADMK3VAfOWv6ekvdwk/Lhbw1nsIHSV16QcAZL81aaFChatRTxntIJlzxKo9qpdk/lHAJnJ0w==
   dependencies:
-    "@eclipse-glsp/layout-elk" "2.1.0"
-    "@eclipse-glsp/server" "2.1.0"
+    "@eclipse-glsp/layout-elk" "2.2.0-next.83+515bc97"
+    "@eclipse-glsp/server" "2.2.0-next.83+515bc97"
     inversify "^6.0.1"
 
 "@eclipse-glsp/cli@~2.0.0":
@@ -254,12 +254,12 @@
     semver "^7.5.1"
     shelljs "^0.8.5"
 
-"@eclipse-glsp/client@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.1.0.tgz#324c48e243cb24d454c9c4a38dcd7effea92b729"
-  integrity sha512-OxQhgcz1VJnmj4IYMSz7Xp4bk50yX/nvrcdVyBvnWJ0S2FF9rJZcdMykooMg19N0nfnG+cjzVa4lbd5Mf975XQ==
+"@eclipse-glsp/client@2.3.0-next.309+b90a740", "@eclipse-glsp/client@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.3.0-next.309.tgz#c5c8a13dfc85f6c6ed1426c410091862d348a2f5"
+  integrity sha512-CcZLBiGnQQztxtR1kE802M6D5MYM6o4zT52RV4qzd1rywzjYZS81lprm3+jYmPK66a2fLiSlDXCix3X2zZPCbg==
   dependencies:
-    "@eclipse-glsp/sprotty" "2.1.0"
+    "@eclipse-glsp/sprotty" "2.3.0-next.309+b90a740"
     autocompleter "^9.1.0"
     file-saver "^2.0.5"
     lodash "4.17.21"
@@ -319,19 +319,19 @@
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/eslint-config/-/eslint-config-2.0.0.tgz#d2070c5e10b0e3fcc3c5ab3a5fcc1dcf0596980e"
   integrity sha512-cne25IFXtX7Ab5oN98IkUulBVrZ7x2mnutyDilTkC132f4vZuPE1aWBY4HOyUbfODVLN2xpQckJQF9X1qdnYNA==
 
-"@eclipse-glsp/graph@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.1.0.tgz#f6d82310ed52ca9eab1c6640857fcc49fbcf2515"
-  integrity sha512-TGreAQ4cSCln0BIBiQ89276RRCBW70Y5ifXJ+qpfWYCbnWnTXwepRdy6Q/OXY5zwjcH7doXSQnmDv5hODVI/ww==
+"@eclipse-glsp/graph@2.2.0-next.83+515bc97":
+  version "2.2.0-next.83"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/graph/-/graph-2.2.0-next.83.tgz#e7c3129211f330e9f6b496942a79284dbaafd883"
+  integrity sha512-yT/nTDF2fnEhdBpPq53kCfx3534R7Z4iCXJPF3ZIKOOTP/UumZbY5m76Em1IW75h6InYeq3u1THueQngSOWZUg==
   dependencies:
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/protocol" next
 
-"@eclipse-glsp/layout-elk@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.1.0.tgz#0a228e6b67673bda69c1c498e9bd8c06d0e11227"
-  integrity sha512-FUE78Du62FEBU9HbF7gcJMlyMFT4C1ZYEPlY/4NOdl6HlI9IbXdeS2z/sv/xIBUCuSDk3YoRQhGe2wLWynRWmg==
+"@eclipse-glsp/layout-elk@2.2.0-next.83+515bc97":
+  version "2.2.0-next.83"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/layout-elk/-/layout-elk-2.2.0-next.83.tgz#3df2322a78e279502e29f0c08b232cc37538e3f4"
+  integrity sha512-ZfJnQ6Phb/a8ONbr8YBKJfFtDNW1d9/DFgb8xL+qtthN36V/Jkk8SoVQC3T3OhlTaVvKYeUpgC6Q5KVjtadRBg==
   dependencies:
-    "@eclipse-glsp/server" "2.1.0"
+    "@eclipse-glsp/server" "2.2.0-next.83+515bc97"
     elkjs "^0.7.1"
 
 "@eclipse-glsp/mocha-config@~2.0.0":
@@ -351,34 +351,34 @@
   dependencies:
     prettier-plugin-packagejson "~2.4.6"
 
-"@eclipse-glsp/protocol@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.1.0.tgz#e76a65a4815c969bfb86a1ab202ad24384a317cc"
-  integrity sha512-CUcVbsjiddDWEuhWKDLgfqslmau2QT6QTF9LyA4/y6Eomv5s8nTexeBMI6hCWL4sHgMfQ4t2zI9zV2a5gIow4A==
+"@eclipse-glsp/protocol@2.3.0-next.309+b90a740", "@eclipse-glsp/protocol@next":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.3.0-next.309.tgz#e30496338846462be6ef8c91c0f42b0e4bd0875a"
+  integrity sha512-KHF90oL4MTo19HEFlvXCpe9xqk92jU4ezbgNALGa27OZ5NOEJgY02aJrs2od4i6YOF6swRO3pPoGts0WH9dDEQ==
   dependencies:
     sprotty-protocol "0.15.0-next.044bba2.13"
     uuid "7.0.3"
     vscode-jsonrpc "^8.0.2"
 
-"@eclipse-glsp/server@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.1.0.tgz#6c281904f974de8ac9893994f2d5c3a144dbf557"
-  integrity sha512-0xPkDLt54hMjNyX33KJFP18O1nUV8U318jYZy6CZfJClnacWrKk8SQKBEUlzhpDFMUrZBvArKmwRylq0pnHpfw==
+"@eclipse-glsp/server@2.2.0-next.83+515bc97":
+  version "2.2.0-next.83"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/server/-/server-2.2.0-next.83.tgz#864147874324bb6e26adf5e2cb30b40ffab10b46"
+  integrity sha512-WBtZFp5SnZbb2ieDuo2lXXsDDEamqzG57Au88S80nEH0YrF6DWlNGfljWwqhIpRlSRZNqc/SEBalIW7CRlF6mg==
   dependencies:
-    "@eclipse-glsp/graph" "2.1.0"
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/graph" "2.2.0-next.83+515bc97"
+    "@eclipse-glsp/protocol" next
     "@types/uuid" "8.3.1"
     commander "^8.3.0"
     fast-json-patch "^3.1.0"
     winston "^3.3.3"
     ws "^8.12.1"
 
-"@eclipse-glsp/sprotty@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.1.0.tgz#4adf93dd501dc65426f7beac145ac007fcb37aa9"
-  integrity sha512-STBH3Af9sTD102mfgr0kplMSkvkkWIOMGLjr7Hl+b5yx8niMrFmy6HGIBVpyw9mb5DW+6eKN+3QjyslTetL8TA==
+"@eclipse-glsp/sprotty@2.3.0-next.309+b90a740":
+  version "2.3.0-next.309"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.3.0-next.309.tgz#e987d28caeb5c3cf26b0986fbd7b671066f902e1"
+  integrity sha512-o97h9GcNEvgTNfwh6pw6AnGQF2HenD6UHzuuN4Pj868c+PZmAEk/hY96QBEOnXCiUn1aI4F2mXHq+3OBiWoIQg==
   dependencies:
-    "@eclipse-glsp/protocol" "2.1.0"
+    "@eclipse-glsp/protocol" "2.3.0-next.309+b90a740"
     autocompleter "^9.1.0"
     snabbdom "^3.5.1"
     sprotty "1.0.0"
@@ -1097,11 +1097,6 @@
   version "16.18.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.60.tgz#0b0f4316906f1bd0e03b640363f67bd4e86958bd"
   integrity sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==
-
-"@types/node@^12.12.0":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.3"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Deprecate the concept of marking actions as locally dispatched by appending the `__localDispatch` property. This concept is a remainder of the 1.x API implementation and no longer necessary in 2.x. In addition, it conflicted with the default behavior of marking actions received from the server.

- Remove `ExtensionAction` bindings of `RequestClipboardDataAction` and `SetClipboardDataAction` in `vscodeCopyPasteModule`. These bindings where added on accident. As a consequence, related actions dispatched in the webview client where also forwarded back to the host extension where they were not handled.

Fixes https://github.com/eclipse-glsp/glsp/issues/1254

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Test with different integration kinds. Diagram rendering should now work again.

#### Follow-ups
https://github.com/eclipse-glsp/glsp/issues/1259

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

- [x] This PR should be mentioned in the changelog
- [x] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
- [API]  The `VsCodeGLSPModelSource` and `ExtensionAction` are  now deprecated. 
       - `VsCodeGLSPModelSource`: Rebinding to a custom model source is no longer necessary.  Use the default `GLSPModelSource` instead.
       - `ExtensionAction`:  The concept of marking actions as locally dispatched `ExtensionAction`s is no longer necessary and usage is discouraged.

