### PR TITLE
Remove contextMenuModule per default

### DIFF
--- a/packages/vscode-integration-webview/src/default-modules.ts
+++ b/packages/vscode-integration-webview/src/default-modules.ts
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import { ModuleConfiguration } from '@eclipse-glsp/client';
+import { ModuleConfiguration, contextMenuModule } from '@eclipse-glsp/client';
 import { vscodeCopyPasteModule } from './features/copyPaste/copy-paste-module';
 import { vscodeDefaultModule } from './features/default/default-module';
 import { vscodeExportModule } from './features/export/export-module';
@@ -30,5 +30,6 @@ export const VSCODE_DEFAULT_MODULES = [
 ] as const;
 
 export const VSCODE_DEFAULT_MODULE_CONFIG: ModuleConfiguration = {
-    add: [...VSCODE_DEFAULT_MODULES]
+    add: [...VSCODE_DEFAULT_MODULES],
+    remove: [contextMenuModule]
 };

--- a/packages/vscode-integration-webview/src/glsp-diagram-widget.ts
+++ b/packages/vscode-integration-webview/src/glsp-diagram-widget.ts
@@ -73,7 +73,15 @@ export abstract class GLSPDiagramWidget {
             containerDiv.addEventListener('mouseleave', e => this.handleMouseLeave(e));
             window.addEventListener('focus', e => this.handleFocusChange(e, true));
             window.addEventListener('blur', e => this.handleFocusChange(e, false));
+            window.addEventListener('contextmenu', e => this.handleContextMenu(e));
         }
+    }
+
+    handleContextMenu(e: MouseEvent): void {
+        // Prevent the default context menu for now
+        // Should be removed once we provide a proper context menu integration
+        e.preventDefault();
+        window.focus();
     }
 
     handleMouseEnter(e: MouseEvent): void {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Remove context menu module for now as it is not supported in VS Code (https://github.com/eclipse-glsp/glsp/issues/414)
 and causes focus issues
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
