### PR TITLE
add style for sprotty text using vscode variables for theme support

### DIFF
--- a/packages/vscode-integration-webview/css/diagram.css
+++ b/packages/vscode-integration-webview/css/diagram.css
@@ -118,3 +118,11 @@ body {
 .sprotty-projection-bar.vertical.bordered-projection-bar {
     width: 15px;
 }
+
+.sprotty text {
+    fill: var(--vscode-editor-background);
+}
+
+.sprotty-edge text {
+    fill: var(--vscode-foreground);
+}


### PR DESCRIPTION
This is a PR for reported issue #1431 - Visual Studio Code Integration theme support.

#### What it does
It just adds css overrides for sprotty text using vscode variables for better theme support.

#### How to test
When changing the theme in VSCode the text on nodes/edges remains black, this can be a bit of a problem for dark themes. Whit the change the text on diagram nodes/edges follows the setting of the VSCode theme and everything is visible.