### PR TITLE
GLSP-1497: Correct glsp warning foreground var

### DIFF
--- a/packages/vscode-integration-webview/css/decoration.css
+++ b/packages/vscode-integration-webview/css/decoration.css
@@ -16,7 +16,7 @@
 
 :root {
     --glsp-error-foreground: var(--vscode-inputValidation-errorBorder);
-    --glsp-warning-foreground: var(--vscode-inputValidation-warningBorderd);
+    --glsp-warning-foreground: var(--vscode-inputValidation-warningBorder);
     --glsp-info-foreground: var(--vscode-inputValidation-infoBorder);
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Resolves [#1497](https://github.com/eclipse-glsp/glsp/issues/1497) correcting the VSCode warning background border var referenced from "borderd" to "border"

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
While viewing a diagram in a VSCode webview with warning type validations, notice the warning decorator is black, not yellow. This change resolves this, and rightly sets it to the VSCode warning border yellow. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
