### PR TITLE
GLSP-1455: Allow configuration of messenger instance

### DIFF
--- a/packages/vscode-integration/src/common/glsp-vscode-connector.ts
+++ b/packages/vscode-integration/src/common/glsp-vscode-connector.ts
@@ -90,7 +90,9 @@ export class GlspVscodeConnector<D extends vscode.CustomDocument = vscode.Custom
         vscode.CustomDocumentEditEvent<D> | vscode.CustomDocumentContentChangeEvent<D>
     >();
     protected readonly disposables: vscode.Disposable[] = [];
-    readonly messenger = new Messenger();
+    get messenger(): Messenger {
+        return this.options.messenger;
+    }
 
     /**
      * A subscribable event which fires with an array containing the IDs of all
@@ -121,6 +123,7 @@ export class GlspVscodeConnector<D extends vscode.CustomDocument = vscode.Custom
             },
             onBeforePropagateMessageToClient: (_originalMessage, processedMessage) => processedMessage,
             onBeforePropagateMessageToServer: (_originalMessage, processedMessage) => processedMessage,
+            messenger: new Messenger({ ignoreHiddenViews: false }),
             ...options
         };
 

--- a/packages/vscode-integration/src/common/types.ts
+++ b/packages/vscode-integration/src/common/types.ts
@@ -15,7 +15,8 @@
  ********************************************************************************/
 import { AnyObject, GLSPClient, InitializeResult, hasStringProp } from '@eclipse-glsp/protocol';
 import * as vscode from 'vscode';
-import { WebviewEndpoint } from '.';
+import { Messenger } from 'vscode-messenger';
+import { WebviewEndpoint } from './quickstart-components/webview-endpoint';
 
 /**
  * Any clients registered on the GLSP VSCode integration need to implement this
@@ -189,6 +190,11 @@ export interface GlspVscodeConnectorOptions {
      * is `undefined` the propagation will be cancelled.
      */
     onBeforePropagateMessageToClient?(originalMessage: unknown, processedMessage: unknown, messageChanged: boolean): unknown | undefined;
+
+    /**
+     * Optional property to provide a {@link Messenger} instance that should be used by the connector.
+     */
+    messenger?: Messenger;
 }
 
 export const GLSPDiagramIdentifier = Symbol('GLSPDiagramIdentifier');


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-glsp/glsp/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See [SECURITY.md](https://github.com/eclipse-glsp/glsp/blob/master/SECURITY.md),
to learn how to report vulnerabilities.
-->

#### What it does

- Allow to configure the vscode-messenger instance used by the GLSPVSCodeConnector via consturctor options.
- Set the `ignoreHiddenViews` options to false in the default messenger instance

Fixes https://github.com/eclipse-glsp/glsp/issues/1455
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Changelog

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
