### PR TITLE
Replace use of LayoutOperation with RequestLayoutAction

### DIFF
--- a/packages/vscode-integration/src/common/quickstart-components/configuration-util.ts
+++ b/packages/vscode-integration/src/common/quickstart-components/configuration-util.ts
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { CenterAction, FitToScreenAction, LayoutOperation, RequestExportSvgAction, SelectAllAction } from '@eclipse-glsp/protocol';
+import { CenterAction, FitToScreenAction, RequestLayoutAction, RequestExportSvgAction, SelectAllAction } from '@eclipse-glsp/protocol';
 import * as vscode from 'vscode';
 import { GlspVscodeConnector, SelectionState } from '../glsp-vscode-connector';
 
@@ -51,7 +51,7 @@ export function configureDefaultCommands(context: CommandContext): void {
             connector.dispatchAction(CenterAction.create(selectionState?.selectedElementsIDs ?? []));
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.layout`, () => {
-            connector.dispatchAction(LayoutOperation.create([]));
+            connector.dispatchAction(RequestLayoutAction.create());
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.selectAll`, () => {
             connector.dispatchAction(SelectAllAction.create());


### PR DESCRIPTION
https://github.com/eclipse-glsp/glsp/issues/1561

Replace the use of LayoutOperation with RequestLayoutAction, in order to allow the client to enrich LayoutOperation before sending it to the server. This is necessary because canvasBounds and viewport information are not accessible from the VSCode command

<!-- Please check, when if it applies to your change. -->

-   [ ] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)
