### PR TITLE
Update changelog for v2.7.0

### DIFF
--- a/.claude/skills/generate-changelog/SKILL.md
+++ b/.claude/skills/generate-changelog/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: generate-changelog
+description: Generate changelog entries from merged PRs since the last release. Fetches PR data, classifies changes as normal or breaking, presents for user review, and optionally creates a PR with the updates.
+---
+
+# Changelog Generator
+
+Generate changelog entries by analyzing merged PRs since the last release.
+
+This repository is `eclipse-glsp/glsp-vscode-integration`. PR links and `gh` queries
+must target that repo. Note that the local clone may have multiple git remotes (e.g. a
+personal fork plus `origin`); always resolve PR data against the canonical
+`eclipse-glsp/glsp-vscode-integration` repo. If `gh` cannot infer the right repo, pass
+`--repo eclipse-glsp/glsp-vscode-integration` explicitly.
+
+Execute these phases in order:
+
+1. **Data Gathering** — find last release, fetch PRs, classify, generate entries
+2. **Changelog Update** — write entries into CHANGELOG.md
+3. **Review & Approval** — present the actual diff to the user for review
+4. **PR Creation** (optional) — push and create PR, only if the user requests it
+
+---
+
+## Phase 1: Data Gathering
+
+### Step 1.1: Find the latest release tag
+
+Run:
+
+```bash
+git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+```
+
+Record as `LAST_TAG` (e.g. `v2.6.0`). Get the tag's date:
+
+```bash
+git log -1 --format=%aI $LAST_TAG
+```
+
+Record as `TAG_DATE`.
+
+### Step 1.2: Extract category tags from existing CHANGELOG.md
+
+Read `CHANGELOG.md` and extract all unique `[tag]` patterns from changelog entries (pattern: `-   [tag] ...`). Build a deduplicated vocabulary list preserving original casing.
+
+Common tags in this repo include: `[api]`, `[diagram]`, `[launch]`, `[protocol]`, `[deps]`, `[node]`, `[build]`.
+
+### Step 1.3: Fetch merged PRs since the last release
+
+```bash
+gh pr list --repo eclipse-glsp/glsp-vscode-integration --state merged --search "merged:>TAG_DATE" --json number,title,author,body,labels,mergedAt --limit 100
+```
+
+Use the date portion only from `TAG_DATE` (e.g. `2026-02-10`).
+
+### Step 1.4: Filter PRs
+
+**Skip rules** (in order):
+
+1. PR has the `changelog` label → skip (already tracked in a previous changelog update)
+2. Author login is `dependabot` or `dependabot[bot]` → skip
+3. Title matches version bump patterns → skip:
+    - Starts with `Switch to` and contains `-next`
+    - Title is a bare version like `vX.Y.Z`
+    - Title starts with `Release v`
+4. Title contains `update changelog` (case insensitive) → skip
+5. Title is purely CI/metadata (readme badges, workflow config) AND body does NOT contain `[x] This PR should be mentioned in the changelog` → skip
+
+**Override**: If the PR body contains `[x] This PR should be mentioned in the changelog`, always include it regardless of rules 3-5. PRs with the `changelog` label (rule 1) and dependabot PRs (rule 2) are always skipped.
+
+### Step 1.5: Classify each PR
+
+1. If body contains `[x] This PR introduces a breaking change` → **breaking**
+2. If body contains `[ ] This PR introduces a breaking change` → **normal**
+3. If no checkbox info, analyze title and body:
+    - Breaking keywords: "refactor", "rename", "remove", "replace", "migrate", "breaking", "deprecate"
+    - Clearly non-breaking (bug fix, docs, minor enhancement) → **normal**
+    - Uncertain → flag for user review
+
+### Step 1.6: Assign category tags
+
+Pick the most fitting tag from the vocabulary (Step 1.2) based on PR title and body. If no tag fits, mark as uncertain: `[???/best-guess]`.
+
+### Step 1.7: Generate changelog entries
+
+#### Entry Format
+
+**Normal changes:**
+
+```
+-   [tag] Description [#N](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/N)
+```
+
+**Breaking changes** with migration sub-items:
+
+```
+-   [tag] Description [#N](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/N)
+    -   Migration detail 1
+    -   Migration detail 2
+```
+
+**Multiple PRs for the same change:**
+
+```
+-   [tag] Description [#N](url) [#M](url)
+```
+
+#### Style Guide
+
+**Formatting:**
+
+-   Entry prefix: `-   ` (dash + exactly 3 spaces)
+-   Sub-item indent: 4 spaces + `-   ` (4 spaces from parent dash)
+-   Sub-sub-item indent: 8 spaces + `-   `
+-   Single space between `[tag]` and description text
+-   Single space before PR link at end of line
+-   PR links are mandatory, full URLs: `[#123](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/123)`
+
+**Wording:**
+
+-   Always start with a **present tense imperative verb** (not past tense)
+-   Common verbs: Fix, Improve, Add, Update, Extend, Ensure, Introduce, Remove, Refactor, Rename, Provide, Allow, Support
+-   **Bug fixes**: "Fix a bug that caused/prevented...", "Fix X behavior"
+-   **Features**: "Introduce...", "Add support for...", "Provide..."
+-   **Enhancements**: "Improve...", "Extend...", "Ensure that..."
+-   **Refactors**: "Refactor...", "Rework...", "Rename..."
+-   Be specific — never "Fix various issues"
+
+**Capitalization:**
+
+-   Tags are always lowercase: `[diagram]`, not `[Diagram]`
+-   Description starts lowercase after the tag (unless proper noun or code element)
+-   Section headers: Title Case (`### Potentially Breaking Changes`)
+
+**Description cleanup from PR title:**
+
+-   Remove issue tracker prefixes (e.g. `GLSP-1234:`, `GH-123:`, `ISSUE-456:`)
+-   Remove conventional commit prefixes: `fix:`, `feat:`, `chore:`
+-   Rephrase bug-report style to changelog style:
+    -   BAD: "Edit label UI does not resize on graph zoom"
+    -   GOOD: "Fix edit label UI not resizing on graph zoom"
+-   Keep concise — one line
+
+**Breaking changes:**
+
+-   Describe what changed, why it's breaking, and how to migrate
+-   Extract migration sub-items from the PR body's "What it does" section
+
+---
+
+## Phase 2: Changelog Update
+
+### Step 2.1: Determine the version section
+
+Read `CHANGELOG.md` in the repository root.
+
+This repo's released section headings look like:
+
+```markdown
+## [v2.6.0 - 10/02/2026](https://github.com/eclipse-glsp/glsp-vscode-integration/releases/tag/v2.6.0)
+```
+
+**Active section detection:**
+
+-   An active section has the `- active` suffix (e.g. `## v2.7.0 - active`) instead of a release date
+-   If an active section exists → merge new entries into it
+-   If the topmost section is a released version (has a date, no `- active` suffix) → create a new active section above it
+
+**Creating a new section:**
+
+-   Bump the minor version of `LAST_TAG` (e.g. `v2.6.0` → `v2.7.0`)
+-   Insert after the title line (`# Eclipse GLSP VSCode Integration Changelog`), before the first `## ` heading:
+
+```markdown
+## v2.7.0 - active
+
+### Changes
+
+-   [tag] Entry [#N](url)
+
+### Potentially Breaking Changes
+
+-   [tag] Entry [#N](url)
+    -   Sub-item detail
+```
+
+Only include "Potentially Breaking Changes" if there are breaking entries.
+
+**Merging into existing active section:**
+
+-   Check PR numbers against existing entries to avoid duplicates
+-   Append new entries to the appropriate subsection
+-   Create missing subsections as needed
+
+### Step 2.2: Write the updated CHANGELOG.md
+
+Use the Edit tool to update `CHANGELOG.md` directly in the current working tree. Match existing formatting conventions.
+
+---
+
+## Phase 3: Review & Approval
+
+### Step 3.1: Show the diff
+
+```bash
+git diff CHANGELOG.md
+```
+
+Present the diff to the user.
+
+### Step 3.2: Prompt for uncertain items
+
+List any entries flagged as uncertain (category or breaking status) and ask the user to resolve them.
+
+Even if nothing is uncertain, ask:
+
+> "Does everything look correct, or would you like to adjust any entries?"
+
+### Step 3.3: Collect user feedback
+
+-   **Approve as-is** → done (or proceed to Phase 4 if PR was requested)
+-   **Request edits** → apply changes, show updated diff, ask again
+-   **Resolve uncertain items** → apply, show updated diff
+
+**Do NOT proceed to Phase 4 unless the user explicitly requests a PR.**
+
+---
+
+## Phase 4: PR Creation (Optional)
+
+Only execute this phase if the user explicitly requests a PR (either in their initial prompt or after reviewing the changelog). If the user hasn't mentioned a PR, ask after approval:
+
+> "Would you like me to create a PR for this changelog update, or are you done?"
+
+### Step 4.1: Determine the branch name
+
+Check if `changelog-update` exists on remote:
+
+```bash
+git ls-remote --heads origin changelog-update
+```
+
+If it exists, increment: `changelog-update-2`, `changelog-update-3`, etc.
+
+### Step 4.2: Create branch, commit, and push
+
+Push to the canonical `origin` remote (`eclipse-glsp/glsp-vscode-integration`):
+
+```bash
+git checkout -b BRANCH_NAME
+git add CHANGELOG.md
+git commit -m "Update changelog"
+git push -u origin BRANCH_NAME
+```
+
+### Step 4.3: Create the PR
+
+If the repo has a `.github/PULL_REQUEST_TEMPLATE.md`, use its structure to fill in the PR body. Otherwise use a simple body describing the changelog update.
+
+```bash
+gh pr create --repo eclipse-glsp/glsp-vscode-integration --title "Update changelog" --body "..."
+```
+
+Report the PR URL.
+
+### Step 4.4: Label referenced PRs
+
+Add the `changelog` label to every PR mentioned in the new entries:
+
+```bash
+gh pr edit PR_NUMBER --repo eclipse-glsp/glsp-vscode-integration --add-label "changelog"
+```
+
+Report which PRs were labeled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Eclipse GLSP VSCode Integration Changelog
 
+## v2.7.0 - active
+
+### Changes
+
+-   [build] Switch to ESLint 9.x [#87](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/87)
+-   [example] Align the codicon version used in the example with the version expected by `@eclipse-glsp/client` [#90](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/90)
+-   [diagram] Fix spurious "No Custom Document found" errors by forwarding `onDidChangeCustomDocument` events only for documents owned by the provider when multiple `GlspEditorProvider` instances share a `GlspVscodeConnector` [#92](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/92)
+-   [mcp] Add support for Model Context Protocol integration, bridging the GLSP-announced MCP server into the VS Code MCP definition provider API [#91](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/91)
+    -   Opt-in via an MCP server configuration on the connector; the announced endpoint is registered on startup and deregistered on extension dispose.
+    -   The Workflow example demonstrates the end-to-end wiring, including a copy-URL action and client-side PNG export.
+
+### Potentially Breaking Changes
+
+-   [deps] Update the minimum required Node version to `22` [#88](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/88)
+-   [deps] Raise the minimum required VS Code version to `1.101`, needed for the stabilized MCP definition provider API; installing in earlier versions will fail [#95](https://github.com/eclipse-glsp/glsp-vscode-integration/pull/95)
+
 ## [v2.6.0 - 10/02/2026](https://github.com/eclipse-glsp/glsp-vscode-integration/releases/tag/v2.6.0)
 
 ## [v2.5.0 - 07/09/2025](https://github.com/eclipse-glsp/glsp-vscode-integration/releases/tag/v2.5.0)


### PR DESCRIPTION
#### What it does

Adds a \`generate-changelog\` skill (adapted from the glsp-client repository) under \`.claude/skills/\` and populates the \`v2.7.0\` changelog section with entries generated from PRs merged since \`v2.6.0\`.

Changelog entries:

*Changes*
- [build] Switch to ESLint 9.x (#87)
- [example] Align codicon version with \`@eclipse-glsp/client\` (#90)
- [diagram] Fix spurious "No Custom Document found" errors across shared connectors (#92)
- [mcp] Add Model Context Protocol integration (#91)

*Potentially Breaking Changes*
- [deps] Update minimum Node version to \`22\` (#88)
- [deps] Raise minimum VS Code version to \`1.101\` (#95)

#### How to test

Review the rendered \`CHANGELOG.md\` diff for correctness against the referenced PRs.

#### Follow-ups

None.

#### Changelog

-   [x] This PR should be mentioned in the changelog
-   [ ] This PR introduces a breaking change (if yes, provide more details below for the changelog and the migration guide)